### PR TITLE
Update conn.go to work with Redshift

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -339,7 +339,7 @@ func (c *Conn) connect(config ConnConfig, network, address string, tlsConfig *tl
 	// Go does not support (https://github.com/golang/go/issues/5742)
 	// PostgreSQL recommends disabling (http://www.postgresql.org/docs/9.4/static/runtime-config-connection.html#GUC-SSL-RENEGOTIATION-LIMIT)
 	if tlsConfig != nil {
-		startupMsg.Parameters["ssl_renegotiation_limit"] = "0"
+		//startupMsg.Parameters["ssl_renegotiation_limit"] = "0"
 	}
 
 	// Copy default run-time params


### PR DESCRIPTION
Redshift doesn't support `ssl_renegotiation_limit` when using the dsn option, this is a workaround for that.